### PR TITLE
Add COG format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - Geospatial
       - [LiDAR](docs/formats/geospatial/lidar.md)
       - [Cloud-Optimized Point Cloud](docs/formats/geospatial/copc.md)
+      - [COG](docs/formats/geospatial/cog.md)
   - Metabolomics
       - [ImzML](docs/formats/metabolomics/imzml.md) 
 

--- a/dataplug/formats/geospatial/cog.py
+++ b/dataplug/formats/geospatial/cog.py
@@ -1,0 +1,144 @@
+import logging
+import math
+import os
+from typing import TYPE_CHECKING, List
+
+import boto3
+from rasterio.session import AWSSession
+import rasterio
+from rasterio.windows import Window
+import rasterio.transform
+
+from dataplug import CloudObject
+from dataplug.entities import CloudDataFormat, CloudObjectSlice, PartitioningStrategy
+from dataplug.preprocessing.metadata import PreprocessingMetadata
+from dataplug.util import setup_logging
+
+if TYPE_CHECKING:
+    from dataplug.cloudobject import CloudObject
+
+# Set environment variables for GDAL and AWS
+os.environ["GDAL_HTTP_UNSAFESSL"] = "YES"
+os.environ["CPL_VSIL_CURL_USE_HEAD"] = "NO"
+os.environ["AWS_REQUEST_PAYER"] = "requester"
+
+# Logger configuration
+logger = logging.getLogger(__name__)
+
+# Configure the AWS session (requester pays)
+aws_session = AWSSession(boto3.Session(), requester_pays=True)
+
+
+def preprocess_cog(cloud_object: CloudObject) -> PreprocessingMetadata:
+    logger.info("Starting COG preprocessing: %s", cloud_object.path.key)
+    with cloud_object.open(mode="rb") as cog_file:
+        with rasterio.open(cog_file) as src:
+            meta = src.meta
+            bounds = src.bounds
+            crs = src.crs.to_string()
+            width = src.width
+            height = src.height
+            attrs = {
+                "width": width,
+                "height": height,
+                "crs": crs,
+                "bounds": {
+                    "left": bounds.left,
+                    "bottom": bounds.bottom,
+                    "right": bounds.right,
+                    "top": bounds.top,
+                },
+                "transform": list(src.transform),
+            }
+            logger.debug("Extracted metadata: %s", attrs)
+    return PreprocessingMetadata(attributes=attrs)
+
+
+@CloudDataFormat(preprocessing_function=preprocess_cog)
+class CloudOptimizedGeoTiff:
+    width: int
+    height: int
+    crs: str
+    bounds: dict
+    transform: list
+
+
+def extract_meta(cloud_object: CloudObject):
+    meta = cloud_object.attributes
+    if hasattr(meta, "_asdict"):
+        return meta._asdict()
+    elif isinstance(meta, dict):
+        return meta
+    elif hasattr(meta, "__dict__"):
+        return meta.__dict__
+    else:
+        return meta
+
+
+class BlockWindowSlice(CloudObjectSlice):
+    def __init__(self, window: Window):
+        self.window = window
+        super().__init__()
+
+    def get(self):
+        meta = extract_meta(self.cloud_object)
+        file_url = self.cloud_object.storage.generate_presigned_url(
+            "get_object",
+            Params={
+                "Bucket": self.cloud_object.path.bucket,
+                "Key": self.cloud_object.path.key,
+                "RequestPayer": "requester",
+            },
+            ExpiresIn=300,
+        )
+        try:
+            with rasterio.Env(aws_session=aws_session):
+                with rasterio.open(file_url) as src:
+                    logger.debug("Reading block window %s from COG %s", self.window, self.cloud_object.path.key)
+                    data = src.read(window=self.window)
+            return data
+        except Exception as e:
+            logger.error("Error fetching data from COG %s: %s", self.cloud_object.path.key, e)
+            raise
+
+    def to_file(self, file_name: str):
+        meta = extract_meta(self.cloud_object)
+        file_url = self.cloud_object.storage.generate_presigned_url(
+            "get_object",
+            Params={
+                "Bucket": self.cloud_object.path.bucket,
+                "Key": self.cloud_object.path.key,
+                "RequestPayer": "requester",
+            },
+            ExpiresIn=300,
+        )
+        try:
+            with rasterio.Env(aws_session=aws_session):
+                with rasterio.open(file_url) as src:
+                    profile = src.profile
+                    profile.update({
+                        "width": int(self.window.width),
+                        "height": int(self.window.height),
+                        "transform": rasterio.windows.transform(self.window, src.transform),
+                    })
+                    logger.debug("Writing block window %s to file %s", self.window, file_name)
+                    with rasterio.open(file_name, "w", **profile) as dst:
+                        dst.write(src.read(window=self.window))
+        except Exception as e:
+            logger.error("Error writing file %s for COG %s: %s", file_name, self.cloud_object.path.key, e)
+            raise
+
+
+@PartitioningStrategy(CloudOptimizedGeoTiff)
+def block_window_strategy(cloud_object: CloudObject) -> List[BlockWindowSlice]:
+    """
+    Partition the COG using its internal block windows.
+    """
+    with cloud_object.open("rb") as cog_file:
+        with rasterio.open(cog_file) as src:
+            # Retrieve block windows from band 1 (assuming all bands share the same tiling)
+            windows = list(src.block_windows(1))
+    logger.info("Found %d block windows for COG %s", len(windows), cloud_object.path.key)
+    slices = [BlockWindowSlice(window) for _, window in windows]
+    logger.debug("Created %d block window slices for COG %s", len(slices), cloud_object.path.key)
+    return slices

--- a/docs/formats/geospatial/cog.md
+++ b/docs/formats/geospatial/cog.md
@@ -1,0 +1,19 @@
+# COG
+
+The COG (Cloud Optimized GeoTIFF) plugin provides an efficient way to partition large geospatial raster datasets stored in object storage (e.g., Amazon S3) using Dataplug. This plugin leverages specialized libraries to access and process COG files directly from cloud storage. It extracts essential metadata and supports grid-based partitioning to enable parallel processing of individual image blocks.
+
+
+
+
+
+
+## Installation
+
+The COG plugin requires the following python packages:
+
+- **rasterio**
+- **numpy**
+
+## Partitioning strategies
+
+`grid_partition_strategy`: Splits the raster image into a grid of squared sub-regions. Specify the number of splits along each axis to partition the image into an equal grid for parallel processing.

--- a/examples/cog_example.py
+++ b/examples/cog_example.py
@@ -1,0 +1,34 @@
+from dataplug import CloudObject
+from dataplug.formats.geospatial.cog import CloudOptimizedGeoTiff, block_window_strategy
+import rasterio
+from rasterio.windows import Window, from_bounds
+import rasterio.transform
+import logging
+from rasterio.session import AWSSession
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)  # Show debug messages
+aws_session = AWSSession(boto3.Session(), requester_pays=True)
+
+def main():
+    s3_config = {"region_name": "us-west-2"}
+    cog_url = "s3://sentinel-cogs/sentinel-s2-l2a-cogs/60/C/WQ/2023/12/S2B_60CWQ_20231228_1_L2A/AOT.tif"
+    co = CloudObject.from_s3(CloudOptimizedGeoTiff, cog_url, s3_config=s3_config)
+    co.preprocess()
+    
+    # Partition the COG using block windows strategy.
+    data_slices = co.partition(block_window_strategy)
+    total_pixels = 0
+    for idx, data_slice in enumerate(data_slices):
+        try:
+            chunk_data = data_slice.get()
+            print(chunk_data)
+            print(f"Slice {idx} data shape: {chunk_data.shape}")
+            total_pixels += chunk_data.size
+        except Exception as e:
+            logger.error("Error retrieving slice %d: %s", idx, e)
+    print("Total pixels read across all slices:", total_pixels)
+
+if __name__ == "__main__":
+    main()

--- a/examples/cog_example.py
+++ b/examples/cog_example.py
@@ -1,5 +1,5 @@
 from dataplug import CloudObject
-from dataplug.formats.geospatial.cog import CloudOptimizedGeoTiff, block_window_strategy
+from dataplug.formats.geospatial.cog import CloudOptimizedGeoTiff, grid_partition_strategy
 import rasterio
 from rasterio.windows import Window, from_bounds
 import rasterio.transform
@@ -18,7 +18,7 @@ def main():
     co.preprocess()
     
     # Partition the COG using block windows strategy.
-    data_slices = co.partition(block_window_strategy)
+    data_slices = co.partition(grid_partition_strategy, n_splits=2)
     total_pixels = 0
     for idx, data_slice in enumerate(data_slices):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "smart_open",
     "tqdm",
     "joblib",
-    "rasterio",
 ]
 
 [project.optional-dependencies]
@@ -35,7 +34,8 @@ metabolomics = [
 ]
 geospatial = [
     "laspy",
-    "PDAL"
+    "PDAL",
+    "rasterio",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "smart_open",
     "tqdm",
     "joblib",
+    "rasterio",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In this pull request, I’ve implemented a new partitioning strategy for Cloud Optimized GeoTiff files that leverages the file's internal block windows. This method retrieves the block windows (from band 1) directly from the file and creates slices that match the native tiling, ensuring full file coverage and efficient data processing.

The key changes are:

**> Block Window Partitioning Strategy:**
> I developed the block_window_strategy which uses the COG’s own block windows to partition the file. This means that every slice aligns perfectly with the internal structure of the file, ensuring full coverage without the need for additional grid calculations.
> 
**> BlockWindowSlice Class:**
> I introduced a new slice class, BlockWindowSlice, to manage each block window. This class includes methods to read data from a block window (`get()`) and to write that data to a file (`to_file()`).
> 

This approach should make data processing more efficient and accurate by taking full advantage of the optimized structure of Cloud Optimized GeoTiffs. Let me know what you think!