### PR TITLE
Addition of MeasurementSet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
       - [LiDAR](docs/formats/geospatial/lidar.md)
       - [Cloud-Optimized Point Cloud](docs/formats/geospatial/copc.md)
   - Metabolomics
-      - [ImzML](docs/formats/metabolomics/imzml.md) 
+      - [ImzML](docs/formats/metabolomics/imzml.md)
+  - Astronomics 
+      - [MeasurementSet](formats/astronomics/ms.md)  
 
 - Dataplug follows a **read-only cloud-aware pre-processing** approach to enable **on-the-fly dynamic partitioning of scientific unstructured data**.
   - It is **cloud-aware** because it specifically targets cold raw data residing in huge repositories in object storage (e.g. Amazon S3).

--- a/dataplug/cloudobject.py
+++ b/dataplug/cloudobject.py
@@ -34,7 +34,7 @@ class CloudObject:
             meta_path: S3Path,
             attrs_path: S3Path,
             storage_config: Optional[Dict[str, Any]] = None,
-            is_folder: bool = False
+            is_folder: bool = False                         # Allows to process formats that are defined as folders
     ):
         self._obj_headers: Optional[Dict[str, str]] = None  # Storage headers of the data object
         self._meta_headers: Optional[Dict[str, str]] = None  # Storage headers of the metadata object
@@ -169,7 +169,7 @@ class CloudObject:
     def fetch(self):
         if not self._obj_headers:
             if self._is_folder:
-                self._obj_headers = {'Meta': 'Data'} #Do nothing here??
+                self._obj_headers = {'Meta': 'Data'}        #Dummy metadata to temporarily bypass this. What could we fill this in with? Consider options
             else:
                 logger.info("Fetching object from S3")
                 self._fetch_object()

--- a/dataplug/cloudobject.py
+++ b/dataplug/cloudobject.py
@@ -168,7 +168,8 @@ class CloudObject:
     def fetch(self):
         if not self._obj_headers:
             if self._is_folder:
-                self._obj_headers = {'Meta': 'Data'}        #TODO: Dummy metadata to temporarily bypass this. What could we fill this in with? Consider options
+                logger.info("Working with folder from S3")
+                self._obj_headers = {'Information': 'The data was marked as a folder, therefore it cannot generate headers correctly. This is set in place of the headers'} 
             else:
                 logger.info("Fetching object from S3")
                 self._fetch_object()

--- a/dataplug/cloudobject.py
+++ b/dataplug/cloudobject.py
@@ -168,7 +168,7 @@ class CloudObject:
     def fetch(self):
         if not self._obj_headers:
             if self._is_folder:
-                self._obj_headers = {'Meta': 'Data'}        #Dummy metadata to temporarily bypass this. What could we fill this in with? Consider options
+                self._obj_headers = {'Meta': 'Data'}        #TODO: Dummy metadata to temporarily bypass this. What could we fill this in with? Consider options
             else:
                 logger.info("Fetching object from S3")
                 self._fetch_object()

--- a/dataplug/cloudobject.py
+++ b/dataplug/cloudobject.py
@@ -33,7 +33,8 @@ class CloudObject:
             object_path: S3Path,
             meta_path: S3Path,
             attrs_path: S3Path,
-            storage_config: Optional[Dict[str, Any]] = None
+            storage_config: Optional[Dict[str, Any]] = None,
+            is_folder: bool = False
     ):
         self._obj_headers: Optional[Dict[str, str]] = None  # Storage headers of the data object
         self._meta_headers: Optional[Dict[str, str]] = None  # Storage headers of the metadata object
@@ -51,6 +52,8 @@ class CloudObject:
 
         self._attrs_path = attrs_path  # S3 Path for the attributes object
         self._attrs: Optional[SimpleNamespace] = None
+
+        self._is_folder = is_folder
 
         storage_config = storage_config or {}
         self._s3: S3Client = PickleableS3ClientProxy(**storage_config)
@@ -108,13 +111,14 @@ class CloudObject:
             fetch: Optional[bool] = True,
             metadata_bucket: Optional[str] = None,
             s3_config: Optional[Dict[str, Any]] = None,
+            folder: Optional[bool] = False
     ) -> CloudObject:
         obj_path = S3Path.from_uri(storage_uri)
         if metadata_bucket is None:
             metadata_bucket = obj_path.bucket + ".meta"
         metadata_path = S3Path.from_bucket_key(metadata_bucket, obj_path.key)
         attributes_path = S3Path.from_bucket_key(metadata_bucket, obj_path.key + ".attrs")
-        co = cls(data_format, obj_path, metadata_path, attributes_path, s3_config)
+        co = cls(data_format, obj_path, metadata_path, attributes_path, s3_config,folder)
         if fetch:
             co.fetch()
         return co
@@ -164,15 +168,18 @@ class CloudObject:
 
     def fetch(self):
         if not self._obj_headers:
-            logger.info("Fetching object from S3")
-            self._fetch_object()
+            if self._is_folder:
+                self._obj_headers = {'Meta': 'Data'} #Do nothing here??
+            else:
+                logger.info("Fetching object from S3")
+                self._fetch_object()
         if not self._meta_headers:
             logger.info("Fetching metadata from S3")
             self._fetch_metadata()
 
     def _fetch_object(self):
         self._obj_headers, _ = head_object(self._s3, self._obj_path.bucket, self._obj_path.key)
-
+    
     def _fetch_metadata(self):
         try:
             res, _ = head_object(self._s3, self._meta_path.bucket, self._meta_path.key)

--- a/dataplug/cloudobject.py
+++ b/dataplug/cloudobject.py
@@ -110,15 +110,14 @@ class CloudObject:
             storage_uri: str,
             fetch: Optional[bool] = True,
             metadata_bucket: Optional[str] = None,
-            s3_config: Optional[Dict[str, Any]] = None,
-            folder: Optional[bool] = False
+            s3_config: Optional[Dict[str, Any]] = None
     ) -> CloudObject:
         obj_path = S3Path.from_uri(storage_uri)
         if metadata_bucket is None:
             metadata_bucket = obj_path.bucket + ".meta"
         metadata_path = S3Path.from_bucket_key(metadata_bucket, obj_path.key)
         attributes_path = S3Path.from_bucket_key(metadata_bucket, obj_path.key + ".attrs")
-        co = cls(data_format, obj_path, metadata_path, attributes_path, s3_config,folder)
+        co = cls(data_format, obj_path, metadata_path, attributes_path, s3_config,data_format.is_folder)
         if fetch:
             co.fetch()
         return co

--- a/dataplug/entities.py
+++ b/dataplug/entities.py
@@ -19,11 +19,12 @@ class PreprocessingType(Enum):
 
 
 class CloudDataFormat:
-    def __init__(self, preprocessing_function: Callable = None, finalizer_function: Callable = None):
+    def __init__(self, preprocessing_function: Callable = None, finalizer_function: Callable = None, is_folder=False):
         self.co_class: object = None
 
         self.preprocessing_function = preprocessing_function
         self.finalizer_function = finalizer_function
+        self.is_folder = is_folder
         self.attrs_types = {}
         self.default_attrs = {}
 

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -261,6 +261,10 @@ def _cleanup_ms(input_ms_path, output_ms_path, num_rows):
         return f"Error MS: {str(e)}"
 
 class MSSLice(CloudObjectSlice):   
+    def __init__(self, range_0, range_1, index):
+        super().__init__(range_0, range_1)
+        self.index = index
+
     def get(self):
         # Maybe paths could be handled in a cleanlier way? Or redefine where data is created/stored?
         ms_name = self.cloud_object.path.key
@@ -283,10 +287,11 @@ class MSSLice(CloudObjectSlice):
             os.remove(template_path+".tar")
         
         total_rows = self.range_1 - self.range_0
-        slice_number = self.range_0 // total_rows
+        slice_number = self.index
+        #slice_number = self.range_0 // total_rows
 
-        if (self.range_0 % (slice_number + 1)):
-            slice_number = slice_number + 1
+        #if (self.range_0 % (slice_number + 1)):
+        #    slice_number = slice_number + 1
 
         sliced_outcome = os.path.join("/tmp", f"temp/slice_{slice_number}.ms")            #DEBUG, should probably delete folder later
         cleaned_sliced_path = os.path.join("/tmp", f"output/slice_{slice_number}.ms")  
@@ -329,7 +334,7 @@ def ms_partitioning_strategy(cloud_object: CloudObject, num_chunks: int):
     for i in range(num_chunks):
         chunk_size = rows_per_chunk + (1 if i < remainder else 0)
         end = start + chunk_size - 1
-        slice = MSSLice(start, end)
+        slice = MSSLice(start, end, index=i)
         slices.append(slice)
         start = end + 1
 

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import io
 import logging
+import os
+import tarfile
+import re
 from math import ceil
 from typing import TYPE_CHECKING
+from casacore.tables import table
 
 import pandas as pd
 
@@ -16,24 +20,162 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _create_tarfile(output_filename, source_dir):
+    with tarfile.open(output_filename, "w:gz") as tar:
+        tar.add(source_dir, arcname=os.path.basename(source_dir))
+
+def _calculate_block_size(data_type, shape):
+    type_sizes = {
+        "double": 8,
+        "float": 4,
+        "Complex": 8,
+        "Bool": 1,
+        "Int": 4,
+    }
+    num_elements = 1
+    for dim in shape:
+        num_elements *= dim
+    if data_type == "Bool":
+        return ceil((num_elements * type_sizes[data_type]) / 8)
+    return num_elements * type_sizes[data_type]
+
+
+def _retrieve_ms_from_s3(client, bucket_name, ms_name,base_dir, local_metadata_path="template.ms", criterion="_TSM0"):
+    
+    local_metadata_path = os.path.join(base_dir, local_metadata_path)
+
+    response = client.list_objects_v2(bucket_name, ms_name)
+
+    if 'Contents' not in response:
+        print(f"No se encontraron contenidos en el bucket {bucket_name} con el prefijo {ms_name}")  #debug, maybe throw exception?
+        return []
+    empty_files_info = []
+    
+    for obj in response['Contents']:
+            key = obj['Key']
+            size = obj['Size']
+
+            relative_path = os.path.relpath(key, ms_name)
+
+            local_file_path = os.path.join(local_metadata_path, relative_path)
+            local_dir = os.path.dirname(local_file_path)
+            if not os.path.exists(local_dir):
+                os.makedirs(local_dir)
+
+            if key.endswith(criterion):
+                with open(local_file_path, 'wb') as f:
+                    pass
+                empty_files_info.append({"name": relative_path, "size": size})
+            else:
+                client.download_file(bucket_name, key, local_file_path)
+    
+    tar_path = local_metadata_path + ".tar"
+
+    _create_tarfile(tar_path,local_metadata_path)    
+
+    return empty_files_info, tar_path
+
+
+def _analyze_tiled_columns(ms_path):
+    ms = table(ms_path, readonly=True)
+    structure = ms.showstructure()
+    ms.close()
+
+    blocks = structure.strip().split("\n\n")
+    tiled_columns = []
+    total_rows = None
+
+    for block in blocks:
+        if "TiledColumnStMan" in block:
+            column_metadata = {
+                "filename": None,
+                "type": None,
+                "shape": None,
+                "bucketsize": None
+            }
+
+            match_file = re.search(r"file=(\S+)", block)
+            if match_file:
+                column_metadata["filename"] = match_file.group(1)
+
+            match_data = re.search(r"(\b(?:double|float|Complex|Bool|Int)\b)\s+.*?shape=\[(.*?)\]", block)
+            if match_data:
+                column_metadata["type"] = match_data.group(1)
+                column_metadata["shape"] = [int(x) for x in match_data.group(2).split(",")]
+
+            match_bucketsize = re.search(r"bucketsize=(\d+)", block)
+            if match_bucketsize:
+                column_metadata["bucketsize"] = int(match_bucketsize.group(1))
+
+            if all(key in column_metadata for key in ("filename", "type", "shape", "bucketsize")):
+                column_metadata["block_size"] = _calculate_block_size(
+                    column_metadata["type"], column_metadata["shape"]
+                )
+                tiled_columns.append(column_metadata)
+
+        match_rows = re.search(r"(\d+)\s*rows", block)
+        if match_rows:
+            total_rows = int(match_rows.group(1))
+
+    return tiled_columns, total_rows
 
 def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
+    s3_client = cloud_object.storage()
+    bucket_name = cloud_object.path.bucket
+    ms_name = cloud_object.path.key
+    criterion = "_TSM0"
+
+    clean_ms_name = ms_name.replace('/', '_')
+    base_dir = f"metadata_{clean_ms_name}"
+
+    if not os.path.exists(base_dir):
+        os.makedirs(base_dir)
+
+    empty_files_info, metadata_path = _retrieve_ms_from_s3(        #creates template and returns some metadata
+        client=s3_client,
+        bucket_name=bucket_name,
+        ms_name=ms_name,
+        base_dir=base_dir,
+        local_metadata_path="template.ms",
+        criterion=criterion
+    )
+
+    tiled_metadata, total_rows = _analyze_tiled_columns("template.ms")
+
+    mutables_list = []
+
+    for column in tiled_metadata:
+        column_filename = column["filename"] + criterion
+        for empty_file in empty_files_info:
+            if os.path.basename(empty_file["name"]) == column_filename:
+                    new_mutable = Mutable(empty_file["name"],f"{ms_name}/",empty_file["size"],column["bucketsize"],column["block_size"])
+                    mutables_list.append(new_mutable)
+
     return PreprocessingMetadata(
         attributes={
-            # Here you must mut the key-value attributed pairs that were defined in the CloudDataFormat class
+            "total_rows":total_rows,
+            "mutable_files":mutables_list,
+            "ms_name":ms_name  
         },
-        metadata=...,  # Here you can return any binary metadata that you want to store. You must take care of serialization.
-        metadata_file_path=... # Or you can return a file path to the metadata file
+        metadata_file_path=metadata_path
     )
+
+class Mutable:
+    file_name: str
+    ms_path: str
+    real_size: int
+    bucketsize: int
+    block_size: int
 
 @CloudDataFormat(preprocessing_function=preprocess_ms)
 class MS:
-    attrb1: List[str]
-    attrb2: List[str]
+    ms_name: str
+    mutable_files: List[Mutable]
+    total_rows: int
 
 class MSSLice(CloudObjectSlice):
      def get(self):
-        # Here you can consult your metadata generated for this format
+        # Here you can consult your metadata generated for this format, in here we need to have caution 
         metadata = self.cloud_object.s3.get_object(
                 Bucket=self.cloud_object.meta_path.bucket,
                 Key=self.cloud_object.meta_path.bucket
@@ -49,9 +191,10 @@ class MSSLice(CloudObjectSlice):
         # And finally return the actual chunked data        
         return chunk
 
-@PartitioningStrategy(dataformat=MS)
+@PartitioningStrategy(dataformat=MS)    #here we could define 2 partiton strategies, one that where you specify how many rows you want per file and other that you specify how many resulting files
+                                        #you will obtaain?
 def newformat_partitioning_strategy(cloud_object: CloudObject, num_chunks: int):
-    slices = []
+    slices = [] #get in heres
     for i in range(num_chunks):
         # Here you put the necessary logic for defining the byte ranges required to read a chunk of the data
         range_0 = ...

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -8,12 +8,12 @@ import tarfile
 import re
 from math import ceil
 from typing import TYPE_CHECKING
-#from casacore.tables import table
+from casacore.tables import table
 
-try:    #necessary?
-    from casacore.tables import table
-except ModuleNotFoundError:
-    pass
+#try:    #necessary?
+#    from casacore.tables import table
+#except ModuleNotFoundError:
+#    pass
 
 from ...entities import CloudDataFormat, CloudObjectSlice, PartitioningStrategy
 from ...preprocessing.metadata import PreprocessingMetadata
@@ -48,7 +48,7 @@ def _retrieve_ms_from_s3(client, bucket_name, ms_name, base_dir, local_metadata_
     
     local_metadata_path = os.path.join(base_dir, local_metadata_path)
 
-    response = client.list_objects_v2(bucket_name, ms_name)
+    response = client.list_objects_v2(Bucket=bucket_name,Prefix=ms_name)
 
     if 'Contents' not in response:
         print(f"No se encontraron contenidos en el bucket {bucket_name} con el prefijo {ms_name}")  #debug, maybe throw exception?
@@ -124,7 +124,7 @@ def _analyze_tiled_columns(ms_path):
     return tiled_columns, total_rows
 
 def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
-    s3_client = cloud_object.storage()
+    s3_client = cloud_object.storage
     bucket_name = cloud_object.path.bucket
     ms_name = cloud_object.path.key
     criterion = "_TSM0"
@@ -144,7 +144,7 @@ def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
         criterion=criterion
     )
 
-    tiled_metadata, total_rows = _analyze_tiled_columns("template.ms")
+    tiled_metadata, total_rows = _analyze_tiled_columns(f"{base_dir}/template.ms")
 
     mutables_list = []
 
@@ -165,11 +165,12 @@ def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
     )
 
 class Mutable:
-    file_name: str
-    ms_path: str
-    real_size: int
-    bucketsize: int
-    block_size: int
+    def __init__(self, file_name: str, ms_path: str, real_size: int, bucketsize: int, block_size: int):
+        file_name: str
+        ms_path: str
+        real_size: int
+        bucketsize: int
+        block_size: int
 
 @CloudDataFormat(preprocessing_function=preprocess_ms)
 class MS:

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -166,7 +166,7 @@ def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
         metadata_file_path=metadata_path + ".tar"
     )
 
-@CloudDataFormat(preprocessing_function=preprocess_ms)
+@CloudDataFormat(preprocessing_function=preprocess_ms, is_folder=True)
 class MS:
     ms_name: str
     mutable_files: List[dict]

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -268,7 +268,7 @@ class MSSLice(CloudObjectSlice):
         template_path = metadata_dir + "/template.ms"
 
         if not os.path.exists(metadata_dir):
-
+            print("DEBUG: Trying stuff")
             os.makedirs(metadata_dir, exist_ok=True)    #ensure directory will exist in a worker
 
             meta_key = self.cloud_object.meta_path.key
@@ -277,7 +277,9 @@ class MSSLice(CloudObjectSlice):
             self.cloud_object.storage.download_file(meta_bucket,meta_key,metadata_dir+"/template.ms.tar")
 
             with tarfile.open(template_path+".tar","r") as tar:
-                tar.extractall(path=template_path)
+                tar.extractall(path=metadata_dir)
+
+            os.remove (template_path+".tar")
         
         total_rows = self.range_1 - self.range_0
         slice_number = self.range_0 // total_rows

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -268,6 +268,9 @@ class MSSLice(CloudObjectSlice):
         template_path = metadata_dir + "/template.ms"
 
         if not os.path.exists(metadata_dir):
+
+            os.makedirs(metadata_dir, exist_ok=True)    #ensure directory will exist in a worker
+
             meta_key = self.cloud_object.meta_path.key
             meta_bucket = self.cloud_object.meta_path.bucket
 

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -393,27 +393,23 @@ def ms_partitioning_strategy(cloud_object: CloudObject, num_chunks: int):
     total_rows = cloud_object.get_attribute("total_rows")
     rows_per_time = cloud_object.get_attribute("rows_per_time") 
 
-    if (num_chunks > total_rows/rows_per_time):
-        num_chunks = total_rows // rows_per_time
+    max_chunks = total_rows // rows_per_time
+    num_chunks = min(num_chunks, max_chunks)
 
     slices = []
 
-    print(rows_per_time)
+    times_per_chunk = max_chunks // num_chunks
+    remainder = max_chunks % num_chunks
 
-    rows_per_chunk = total_rows // num_chunks
-    remainder = total_rows % num_chunks
-    
     start = 0
     for i in range(num_chunks):
-        chunk_size = rows_per_chunk + (1 if i < remainder else 0)
-        
-        if chunk_size % rows_per_time != 0:
-            chunk_size = ((chunk_size // rows_per_time) + 1) * rows_per_time
+        my_times = times_per_chunk
+        if remainder > 0:
+            my_times = times_per_chunk + 1
+            remainder -= 1
 
-        if start + chunk_size > total_rows:
-            chunk_size = total_rows - start
-
-        end = start + chunk_size - 1
+        end = start + my_times*rows_per_time - 1
+        print(end)
         slice = MSSLice(start, end, index=i)
         slices.append(slice)
         start = end + 1

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -284,7 +284,7 @@ class MSSLice(CloudObjectSlice):
         total_rows = self.range_1 - self.range_0
         slice_number = self.range_0 // total_rows
 
-        if (self.range_0 % slice_number):
+        if (self.range_0 % (slice_number + 1)):
             slice_number = slice_number + 1
 
         sliced_outcome = os.path.join("/tmp", f"temp/slice_{slice_number}.ms")            #DEBUG, should probably delete folder later

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import io
+import logging
+from math import ceil
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from ...entities import CloudDataFormat, CloudObjectSlice, PartitioningStrategy
+from ...preprocessing.metadata import PreprocessingMetadata
+
+if TYPE_CHECKING:
+    from typing import List
+    from ...cloudobject import CloudObject
+
+logger = logging.getLogger(__name__)
+
+
+def preprocess_ms(cloud_object: CloudObject) -> PreprocessingMetadata:
+    return PreprocessingMetadata(
+        attributes={
+            # Here you must mut the key-value attributed pairs that were defined in the CloudDataFormat class
+        },
+        metadata=...,  # Here you can return any binary metadata that you want to store. You must take care of serialization.
+        metadata_file_path=... # Or you can return a file path to the metadata file
+    )
+
+@CloudDataFormat(preprocessing_function=preprocess_ms)
+class MS:
+    attrb1: List[str]
+    attrb2: List[str]
+
+class MSSLice(CloudObjectSlice):
+     def get(self):
+        # Here you can consult your metadata generated for this format
+        metadata = self.cloud_object.s3.get_object(
+                Bucket=self.cloud_object.meta_path.bucket,
+                Key=self.cloud_object.meta_path.bucket
+        )["Body"]
+        
+        # Perform the necessary HTTP GET operations to get the data
+        chunk = self.cloud_object.s3.get_object(
+                Bucket=self.cloud_object.path.bucket,
+                Key=self.cloud_object.path.bucket,
+                Range=f"bytes={self.range_0}-{self.range_1}"
+        )["Body"]
+        
+        # And finally return the actual chunked data        
+        return chunk
+
+@PartitioningStrategy(dataformat=MS)
+def newformat_partitioning_strategy(cloud_object: CloudObject, num_chunks: int):
+    slices = []
+    for i in range(num_chunks):
+        # Here you put the necessary logic for defining the byte ranges required to read a chunk of the data
+        range_0 = ...
+        range_1 = ...
+        slice = MSSLice(range_0, range_1)
+        slices.append(slice)
+    return slices

--- a/dataplug/formats/astronomics/ms.py
+++ b/dataplug/formats/astronomics/ms.py
@@ -8,7 +8,12 @@ import tarfile
 import re
 from math import ceil
 from typing import TYPE_CHECKING
-from casacore.tables import table
+#from casacore.tables import table
+
+try:    #necessary?
+    from casacore.tables import table
+except ModuleNotFoundError:
+    pass
 
 from ...entities import CloudDataFormat, CloudObjectSlice, PartitioningStrategy
 from ...preprocessing.metadata import PreprocessingMetadata

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,6 @@
 
 ### Metabolomics
 - [ImzML](formats/metabolomics/imzml.md)
+
+### Astronomics
+- [MeasurementSet](formats/astronomics/ms.md)

--- a/docs/formats/astronomics/ms.md
+++ b/docs/formats/astronomics/ms.md
@@ -16,5 +16,4 @@ You can follow the instructions [here](...) to install it.
 
 ## Partitioning strategies
 
-- `ms_partitioning_strategy`: Splits the data into a given number of sub-sets that are individually viable MeasurementSet files. 
-- `ms_partitioning_strategy_rowsize`: Splits the data into as many individually viable MeasurementSet files necessary to fulfill that each of them has the given number of rows. 
+- `ms_partitioning_strategy`: Splits the data into a given number of sub-sets that are individually viable MeasurementSet files, based on a time restriction. 

--- a/docs/formats/astronomics/ms.md
+++ b/docs/formats/astronomics/ms.md
@@ -1,0 +1,20 @@
+# MeasurementSet
+
+## Installation
+
+The MeasurementSet plugin requires the following python packages:
+
+```
+casacore
+```
+
+You can install them using `pip`.
+
+Additionally, the MeasurementSet plugin requires ... for pre-processing.
+You can follow the instructions [here](...) to install it.
+
+
+## Partitioning strategies
+
+- `ms_partitioning_strategy`: Splits the data into a given number of sub-sets that are individually viable MeasurementSet files. 
+- `ms_partitioning_strategy_rowsize`: Splits the data into as many individually viable MeasurementSet files necessary to fulfill that each of them has the given number of rows. 

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -27,8 +27,14 @@ if __name__ == "__main__":
 
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=4)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=3)
 
-    first_slice = slices[1]
+    first_slice = slices[0]
+    second_slice = slices[1]
+    third_slice = slices[2]
     slice_data = first_slice.get()
+    print(slice_data)
+    slice_data = second_slice.get()
+    print(slice_data)
+    slice_data = third_slice.get()
     print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -32,17 +32,21 @@ if __name__ == "__main__":
     print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=4)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=5)
+    for slice in slices:
+        print(slice)
+        slice_data = slice.get()
+        print(slice_data)
 
-    first_slice = slices[0]
-    slice_data = first_slice.get()
-    print(slice_data)
-    second_slice = slices[1]
-    slice_data = second_slice.get()
-    print(slice_data)
-    third_slice = slices[2]
-    slice_data = third_slice.get()
-    print(slice_data)
-    fourth_slice = slices[3]
-    slice_data = fourth_slice.get()
-    print(slice_data)
+    # first_slice = slices[0]
+    # slice_data = first_slice.get()
+    # print(slice_data)
+    # second_slice = slices[1]
+    # slice_data = second_slice.get()
+    # print(slice_data)
+    # third_slice = slices[2]
+    # slice_data = third_slice.get()
+    # print(slice_data)
+    # fourth_slice = slices[3]
+    # slice_data = fourth_slice.get()
+    # print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -32,10 +32,10 @@ if __name__ == "__main__":
     print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=13)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=2)
     for slice in slices:
         print(slice)
-        #slice_data = slice.get()
+        slice_data = slice.get()
         #print(slice_data)
 
     # first_slice = slices[0]

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -1,0 +1,39 @@
+from dataplug import CloudObject
+from dataplug.formats.ms import MS, ms_partitioning_strategy
+from dataplug.preprocessing import LocalPreprocessor
+
+if __name__ == "__main__":
+    # Localhost minio config
+    local_minio = {
+        "aws_access_key_id": "minioadmin",
+        "aws_secret_access_key": "minioadmin",
+        #"region_name": "us-east-1",
+        "endpoint_url": "http://localhost:9000",
+        "botocore_config_kwargs": {"signature_version": "s3v4"},
+        #"role_arn": "arn:aws:iam::123456789012:role/S3Access",
+        #"use_token": True,
+    }
+
+    ms_uri = "s3://astronomics/partition_1.ms"
+    true = True
+
+    co = CloudObject.from_s3(
+        MS,
+        ms_uri,
+        s3_config=local_minio,
+    )
+
+    backend = LocalPreprocessor()
+    co.preprocess(backend, force=True)
+
+    # co.preprocessing(backend, force=True)
+
+    # print(co.get_attribute('points'))
+    # print(co.attributes.points)
+    # print(co['points'])
+
+    #slices = co.partition(ms_partitioning_strategy, num_chunks=4)
+
+    #first_slice = slice[1]
+    #slice_data = first_slice.get()
+    #print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -35,12 +35,12 @@ if __name__ == "__main__":
 
     # co.preprocessing(backend, force=True)
 
-    # print(co.get_attribute('points'))
+    print(co.attributes)
     # print(co.attributes.points)
     # print(co['points'])
 
-    #slices = co.partition(ms_partitioning_strategy, num_chunks=4)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=4)
 
-    #first_slice = slice[1]
-    #slice_data = first_slice.get()
-    #print(slice_data)
+    first_slice = slices[2]
+    slice_data = first_slice.get()
+    print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -3,6 +3,7 @@ from dataplug import CloudObject
 from dataplug.formats.astronomics.ms import MS, ms_partitioning_strategy
 
 if __name__ == "__main__":
+    
     # Localhost minio config
     local_minio = {
         "credentials": {
@@ -14,7 +15,7 @@ if __name__ == "__main__":
         # "botocore_config_kwargs": {"signature_version": "s3v4"},  Optional
     }
 
-    ms_uri = "s3://astronomics-test/smallms.ms"
+    ms_uri = "s3://astronomics-test/smallms.ms" #Replace with your MeasurementSet URI
 
     co = CloudObject.from_s3(
         MS,
@@ -24,29 +25,19 @@ if __name__ == "__main__":
     )
 
     parallel_config = {"verbose": 10}
+    
+    #Measuring time of preprocessing stage
     start_time = time.time()
+    
     co.preprocess(parallel_config, force=True)
+    
     end_time = time.time()
 
     elapsed_time = end_time - start_time
     print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
-    #print(co.attributes)
 
     slices = co.partition(ms_partitioning_strategy, num_chunks=2)
     for slice in slices:
         print(slice)
         slice_data = slice.get()
-        #print(slice_data)
-
-    # first_slice = slices[0]
-    # slice_data = first_slice.get()
-    # print(slice_data)
-    # second_slice = slices[1]
-    # slice_data = second_slice.get()
-    # print(slice_data)
-    # third_slice = slices[2]
-    # slice_data = third_slice.get()
-    # print(slice_data)
-    # fourth_slice = slices[3]
-    # slice_data = fourth_slice.get()
-    # print(slice_data)
+        print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -1,30 +1,37 @@
 from dataplug import CloudObject
-from dataplug.formats.ms import MS, ms_partitioning_strategy
-from dataplug.preprocessing import LocalPreprocessor
+from dataplug.formats.astronomics.ms import MS, ms_partitioning_strategy
 
 if __name__ == "__main__":
     # Localhost minio config
     local_minio = {
-        "aws_access_key_id": "minioadmin",
-        "aws_secret_access_key": "minioadmin",
-        #"region_name": "us-east-1",
-        "endpoint_url": "http://localhost:9000",
-        "botocore_config_kwargs": {"signature_version": "s3v4"},
-        #"role_arn": "arn:aws:iam::123456789012:role/S3Access",
-        #"use_token": True,
+        "credentials": {
+            "AccessKeyId": "minioadmin",
+            "SecretAccessKey": "minioadmin",
+        },
+        "endpoint_url": "http://127.0.0.1:9000",  # MinIO server address
+        # "region_name": "us-east-1",  # Optional but recommended
+        # "botocore_config_kwargs": {"signature_version": "s3v4"},  # Optional
     }
 
+    # instalar mc para minio
+    # setuppear un minio con sts
+    # probar si funciona?
+    # crear un bucket y subir el ms
+    # probar este codigo de nuevo
+
     ms_uri = "s3://astronomics/partition_1.ms"
-    true = True
 
     co = CloudObject.from_s3(
         MS,
         ms_uri,
+        False,
         s3_config=local_minio,
+        folder = True
+        #if directory equals true
     )
 
-    backend = LocalPreprocessor()
-    co.preprocess(backend, force=True)
+    parallel_config = {"verbose": 10}
+    co.preprocess(parallel_config, force=True)
 
     # co.preprocessing(backend, force=True)
 

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -32,16 +32,17 @@ if __name__ == "__main__":
     print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=2)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=4)
 
     first_slice = slices[0]
     slice_data = first_slice.get()
     print(slice_data)
     second_slice = slices[1]
-    #third_slice = slices[2]
-    #slice_data = first_slice.get()
-    #print(slice_data)
     slice_data = second_slice.get()
     print(slice_data)
-    #slice_data = third_slice.get()
-    #print(slice_data)
+    third_slice = slices[2]
+    slice_data = third_slice.get()
+    print(slice_data)
+    fourth_slice = slices[3]
+    slice_data = fourth_slice.get()
+    print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -19,8 +19,7 @@ if __name__ == "__main__":
         MS,
         ms_uri,
         False,
-        s3_config=local_minio,
-        folder = True
+        s3_config=local_minio
     )
 
     parallel_config = {"verbose": 10}

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -9,15 +9,9 @@ if __name__ == "__main__":
             "SecretAccessKey": "minioadmin",
         },
         "endpoint_url": "http://127.0.0.1:9000",  # MinIO server address
-        # "region_name": "us-east-1",  # Optional but recommended
-        # "botocore_config_kwargs": {"signature_version": "s3v4"},  # Optional
+        # "region_name": "us-east-1",                               Optional
+        # "botocore_config_kwargs": {"signature_version": "s3v4"},  Optional
     }
-
-    # instalar mc para minio
-    # setuppear un minio con sts
-    # probar si funciona?
-    # crear un bucket y subir el ms
-    # probar este codigo de nuevo
 
     ms_uri = "s3://astronomics/partition_1.ms"
 
@@ -27,20 +21,15 @@ if __name__ == "__main__":
         False,
         s3_config=local_minio,
         folder = True
-        #if directory equals true
     )
 
     parallel_config = {"verbose": 10}
     co.preprocess(parallel_config, force=True)
 
-    # co.preprocessing(backend, force=True)
-
-    print(co.attributes)
-    # print(co.attributes.points)
-    # print(co['points'])
+    #print(co.attributes)
 
     slices = co.partition(ms_partitioning_strategy, num_chunks=4)
 
-    first_slice = slices[2]
+    first_slice = slices[1]
     slice_data = first_slice.get()
     print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -1,3 +1,4 @@
+import time 
 from dataplug import CloudObject
 from dataplug.formats.astronomics.ms import MS, ms_partitioning_strategy
 
@@ -13,7 +14,7 @@ if __name__ == "__main__":
         # "botocore_config_kwargs": {"signature_version": "s3v4"},  Optional
     }
 
-    ms_uri = "s3://astronomics/partition_1.ms"
+    ms_uri = "s3://astronomics-test/smallms.ms"
 
     co = CloudObject.from_s3(
         MS,
@@ -23,18 +24,24 @@ if __name__ == "__main__":
     )
 
     parallel_config = {"verbose": 10}
+    start_time = time.time()
     co.preprocess(parallel_config, force=True)
+    end_time = time.time()
 
+    elapsed_time = end_time - start_time
+    print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=3)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=2)
 
     first_slice = slices[0]
-    second_slice = slices[1]
-    third_slice = slices[2]
     slice_data = first_slice.get()
     print(slice_data)
+    second_slice = slices[1]
+    #third_slice = slices[2]
+    #slice_data = first_slice.get()
+    #print(slice_data)
     slice_data = second_slice.get()
     print(slice_data)
-    slice_data = third_slice.get()
-    print(slice_data)
+    #slice_data = third_slice.get()
+    #print(slice_data)

--- a/examples/ms_example.py
+++ b/examples/ms_example.py
@@ -32,11 +32,11 @@ if __name__ == "__main__":
     print(f"Preprocess stage took {elapsed_time:.2f} seconds.")
     #print(co.attributes)
 
-    slices = co.partition(ms_partitioning_strategy, num_chunks=5)
+    slices = co.partition(ms_partitioning_strategy, num_chunks=13)
     for slice in slices:
         print(slice)
-        slice_data = slice.get()
-        print(slice_data)
+        #slice_data = slice.get()
+        #print(slice_data)
 
     # first_slice = slices[0]
     # slice_data = first_slice.get()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ geospatial = [
     "laspy",
     "PDAL"
 ]
+astronomics = [
+    "casacore"
+]
 
 
 [tool.setuptools]


### PR DESCRIPTION
This addition enables  Dataplug to process the MeasurementSet Format. 

Requesting a slice will create a directory named /partition_n.ms, representing a fully functional slice of a larger MS. Dataplug will return the path to this directory for further processing. 

A slight change has been made to the  CloudDataFormat definition to support CloudObjects (formats) that rely on  directory structures (i.e. folders rather than a single file). 
This small update  shouldn't affect any previously defined formats. This change is enabled by using  the `is_folder=True` key at the time of defining a new directory data format 

